### PR TITLE
Change persistent disk usage requirements

### DIFF
--- a/migrate-percona-mysql.html.md.erb
+++ b/migrate-percona-mysql.html.md.erb
@@ -25,9 +25,9 @@ PAS UAA downtime caused by internal MySQL migration also temporarily prevents us
 1. **Scale Down Your Cluster**: If your internal databases MySQL cluster runs three or more nodes, scale it down horizontally to a single node before you migrate. In the PAS tile > **Resource Config** > **MySQL Server** settings, set **Instances** to `1`. Click **Save**.
 <p class='note'><strong>Note:</strong> Do not click <strong>Review Pending Changes</strong> and <strong>Apply Changes</strong> yet.</p>
 
-1. **Scale Up the Persistent Disk of the Server Node**: Migrating the database demands twice the normal disk space on the MySQL server. To ensure that the single remaining MySQL server node currently uses at most `40%` of its persistent disk, do the following:  
+1. **Scale Up the Persistent Disk of the Server Node**: Migrating the database can demand up to 3 times the normal disk space on the MySQL server. To ensure that the single remaining MySQL server node currently uses at most `30%` of its persistent disk, do the following:  
 	1. Check the persistent disk usage of the MySQL Server job in the **Status** tab of the PAS tile. 
-	2. If the MySQL Server job disk usage exceeds 40%, scale it up vertically by increasing its persistent disk.
+	2. If the MySQL Server job disk usage exceeds 30%, scale it up vertically by increasing its persistent disk.
 
 1. **Change the System Databases Location**: In the PAS tile > **Databases** pane, under **Choose the location of your system databases**, select to **Internal Databases - MySQL - Percona XtraDB Cluster**. Click **Save**.
 <%= image_tag("system-db-tls.png") %>


### PR DESCRIPTION
When migrating we failed to account for the generation of binlog files when migrating. To be on the safe side we should make the disk usage `30%` instead of `40%`.